### PR TITLE
actually install viacore-lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "async": "^0.9.2",
-    "bitcore-lib": "https://github.com/viacoin/viacore-lib",
+    "viacore-lib": "https://github.com/viacoin/viacore-lib",
     "bitcore-lib-cash": "^0.16.1",
     "body-parser": "^1.11.0",
     "compression": "^1.6.2",


### PR DESCRIPTION
specifying the wrong package name will cause it to not install without throwing exceptions.