### PR TITLE
Viacoin: use viacoin's rate ticker

### DIFF
--- a/lib/fiatrateproviders/bitpay.js
+++ b/lib/fiatrateproviders/bitpay.js
@@ -2,7 +2,7 @@ var _ = require('lodash');
 
 var provider = {
   name: 'BitPay',
-  url: 'https://bitpay.com/api/rates/',
+  url: 'https://rates.viacoin.org/api/rates/',
   parseFn: function(raw) {
     var rates = _.compact(_.map(raw, function(d) {
       if (!d.code || !d.rate) return null;


### PR DESCRIPTION
This service is being used to periodically log the price of the coin. So you can get historical rates when viewing a transaction that happened in the past.